### PR TITLE
Clickable GitHub issues in release notes and new version notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Full changelog
+
+## Fixed
+
+- Pulling did not update content (i.e. about texts) and teams (#107)
+
 ## [1.5.1] - 2026-04-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Full changelog
+- View release notes of past versions
 
-## Fixed
+### Fixed
 
 - Pulling did not update content (i.e. about texts) and teams (#107)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@ import { useRouter } from "vue-router";
 import NotificationHandler from "./components/notifications/NotificationHandler.vue";
 import { useThemeStore } from "./stores/theme";
 import { useAccountsStore } from "./stores/accounts";
+import { Notifications } from "./components/notifications/createNotification";
 
 const router = useRouter();
 const theme = useThemeStore();
@@ -21,6 +22,15 @@ onMounted(() => {
 
     theme.init();
     useAccountsStore().migrate();
+
+    const lastVersion = globalThis.localStorage.getItem("version") || APP_VERSION;
+    globalThis.localStorage.setItem("version", APP_VERSION);
+    if (lastVersion != APP_VERSION) {
+        Notifications.addRedirect(`Welcome to bracketeer v${APP_VERSION}!`, {
+            redirectText: "View release notes.",
+            redirect: "/settings/general/about",
+        });
+    }
 });
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,7 +27,7 @@ onMounted(() => {
     globalThis.localStorage.setItem("version", APP_VERSION);
     if (lastVersion != APP_VERSION) {
         Notifications.addRedirect(`Welcome to bracketeer v${APP_VERSION}!`, {
-            redirectText: "View release notes.",
+            actionText: "View release notes.",
             redirect: "/settings/general/about",
         });
     }

--- a/src/components/MarkdownRender.vue
+++ b/src/components/MarkdownRender.vue
@@ -47,5 +47,10 @@ div.md {
     & ol {
         margin-top: var(--spacing-xxs);
     }
+
+    li > ul,
+    li > ol {
+        margin-top: 0;
+    }
 }
 </style>

--- a/src/components/ReleaseNotes.vue
+++ b/src/components/ReleaseNotes.vue
@@ -1,10 +1,17 @@
 <script lang="ts" setup>
+import { computed } from "vue";
 import MarkdownRender from "./MarkdownRender.vue";
 import { type Version } from "@/helpers/releaseNotes";
+import { GITHUB_LINK } from "@/helpers/common";
 
-defineProps<{
+const props = defineProps<{
     version: Version;
 }>();
+
+const ISSUE_REGEX = /#(\d+)/gm;
+const markdown = computed(() =>
+    props.version.changes.replaceAll(ISSUE_REGEX, `[#$1](${GITHUB_LINK}/issues/$1)`),
+);
 </script>
 <template>
     <div class="version card">
@@ -13,7 +20,7 @@ defineProps<{
             <span class="text-muted">{{ version.date.toLocaleDateString() }}</span>
         </div>
         <div class="release-notes">
-            <MarkdownRender :source="version.changes" />
+            <MarkdownRender :source="markdown" />
         </div>
     </div>
 </template>

--- a/src/components/notifications/ClosableNotification.vue
+++ b/src/components/notifications/ClosableNotification.vue
@@ -18,12 +18,15 @@ const props = defineProps({
 const emit = defineEmits(["remove"]);
 const router = useRouter();
 
-const remove = (id: string) => {
-    emit("remove", id);
+const remove = () => {
+    emit("remove", props.notification.id);
 };
 
 const click = () => {
-    emit("remove", props.notification.id);
+    if (props.notification.type === "redirect") {
+        return;
+    }
+    remove();
     if (props.notification.onClick) {
         props.notification.onClick();
     }
@@ -37,7 +40,8 @@ const click = () => {
     <div
         :class="{
             [notification.type]: true,
-            'cursor-pointer': notification.redirect || notification.onClick,
+            'cursor-pointer':
+                (notification.type !== 'redirect' && notification.redirect) || notification.onClick,
         }"
         class="notification"
         @click.stop.prevent="click"
@@ -56,6 +60,7 @@ const click = () => {
                 v-if="notification.actionText && notification.redirect"
                 class="action"
                 :to="notification.redirect"
+                @click.prevent.stop="remove"
             >
                 <ion-icon name="arrow-forward"></ion-icon>
                 {{ notification.actionText }}
@@ -64,7 +69,7 @@ const click = () => {
         <ion-icon
             name="close-outline"
             class="close"
-            @click.stop.prevent="remove(notification.id)"
+            @click.stop.prevent="remove"
         />
     </div>
 </template>
@@ -97,6 +102,7 @@ const click = () => {
 
     &.redirect {
         background: var(--color-surface);
+        color: var(--color-text-primary);
     }
 
     h4,

--- a/src/components/notifications/ClosableNotification.vue
+++ b/src/components/notifications/ClosableNotification.vue
@@ -5,12 +5,12 @@
 
 <script lang="ts" setup>
 import type { PropType } from "vue";
-import type { INotification } from "./createNotification";
+import type { IFullNotification } from "./createNotification";
 import { useRouter } from "vue-router";
 
 const props = defineProps({
     notification: {
-        type: Object as PropType<INotification>,
+        type: Object as PropType<IFullNotification>,
         required: true,
     },
 });
@@ -52,6 +52,14 @@ const click = () => {
             >
                 {{ notification.details }}
             </span>
+            <router-link
+                v-if="notification.actionText && notification.redirect"
+                class="action"
+                :to="notification.redirect"
+            >
+                <ion-icon name="arrow-forward"></ion-icon>
+                {{ notification.actionText }}
+            </router-link>
         </div>
         <ion-icon
             name="close-outline"
@@ -87,9 +95,17 @@ const click = () => {
         background-color: var(--color-brand-yellow);
     }
 
+    &.redirect {
+        background: var(--color-surface);
+    }
+
     h4,
     p {
         margin: 0;
+    }
+
+    &.cursor-pointer {
+        cursor: pointer;
     }
 }
 
@@ -100,5 +116,11 @@ const click = () => {
 
 .details {
     display: block;
+}
+
+.action {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
 }
 </style>

--- a/src/components/notifications/NotificationHandler.vue
+++ b/src/components/notifications/NotificationHandler.vue
@@ -9,7 +9,7 @@ import ClosableNotification from "./ClosableNotification.vue";
 import YesNoNotification from "./YesNoNotification.vue";
 import type { IFullNotification, IYesNoNotification } from "./createNotification";
 
-const closableNotifications = ["success", "error", "info", "warning"];
+const closableNotifications = ["success", "error", "info", "warning", "redirect"];
 
 const notifications = ref<IFullNotification[]>([]);
 

--- a/src/components/notifications/createNotification.test.ts
+++ b/src/components/notifications/createNotification.test.ts
@@ -147,6 +147,25 @@ describe("Notifications", () => {
         });
     });
 
+    describe("addRedirect", () => {
+        it("should dispatch redirect notification with action text", () => {
+            let capturedEvent: CustomEvent<IFullNotification> | null = null;
+            globalThis.addEventListener("notification.add", ((e: Event) => {
+                capturedEvent = e as CustomEvent<IFullNotification>;
+            }) as EventListener);
+
+            Notifications.addRedirect("Open release notes", {
+                actionText: "View release notes",
+                redirect: "/settings/general/about",
+            });
+
+            expect(capturedEvent!.detail.message).toBe("Open release notes");
+            expect(capturedEvent!.detail.type).toBe("redirect");
+            expect(capturedEvent!.detail.actionText).toBe("View release notes");
+            expect(capturedEvent!.detail.redirect).toBe("/settings/general/about");
+        });
+    });
+
     describe("addYesNo", () => {
         it("should dispatch yes-no notification event", () => {
             let capturedEvent: CustomEvent<IFullNotification> | null = null;
@@ -169,9 +188,9 @@ describe("Notifications", () => {
 
         it("should include all callback parameters", () => {
             let capturedEvent: CustomEvent<IFullNotification> | null = null;
-            globalThis.addEventListener("notification.add", ((e: Event) => {
+            globalThis.addEventListener("notification.add", (e: Event) => {
                 capturedEvent = e as CustomEvent<IFullNotification>;
-            }) as EventListener);
+            });
 
             const onYes = vi.fn();
             const onNo = vi.fn();

--- a/src/components/notifications/createNotification.ts
+++ b/src/components/notifications/createNotification.ts
@@ -4,7 +4,7 @@ export interface INotification {
     id: string;
     message: string;
     details?: string;
-    type: "success" | "error" | "info" | "warning" | "yes-no";
+    type: "success" | "error" | "info" | "warning" | "yes-no" | "redirect";
     timeout?: number;
     onClick?: () => void;
     redirect?: string;
@@ -21,6 +21,7 @@ export interface IFullNotification extends INotification {
     onYes?: () => void;
     onNo?: () => void;
     onTimeout?: () => void;
+    actionText?: string;
 }
 
 const triggerNotification = (notification: IFullNotification) => {
@@ -135,6 +136,36 @@ export const Notifications = {
             timeout,
             onClick,
             redirect,
+        };
+        triggerNotification(notification);
+        return id;
+    },
+    addRedirect(
+        message: string,
+        {
+            details,
+            redirectText,
+            timeout,
+            onClick,
+            redirect,
+        }: {
+            details?: string;
+            redirectText?: string;
+            timeout?: number;
+            onClick?: () => void;
+            redirect?: string;
+        } = {},
+    ) {
+        const id = generateId();
+        const notification: IFullNotification = {
+            id,
+            message,
+            details,
+            type: "redirect",
+            timeout,
+            onClick,
+            redirect,
+            actionText: redirectText,
         };
         triggerNotification(notification);
         return id;

--- a/src/components/notifications/createNotification.ts
+++ b/src/components/notifications/createNotification.ts
@@ -144,17 +144,17 @@ export const Notifications = {
         message: string,
         {
             details,
-            redirectText,
+            actionText,
             timeout,
             onClick,
             redirect,
         }: {
+            redirect: string;
+            actionText: string;
             details?: string;
-            redirectText?: string;
             timeout?: number;
             onClick?: () => void;
-            redirect?: string;
-        } = {},
+        },
     ) {
         const id = generateId();
         const notification: IFullNotification = {
@@ -165,7 +165,7 @@ export const Notifications = {
             timeout,
             onClick,
             redirect,
-            actionText: redirectText,
+            actionText,
         };
         triggerNotification(notification);
         return id;

--- a/src/helpers/releaseNotes.test.ts
+++ b/src/helpers/releaseNotes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseVersions, VERSIONS } from "./releaseNotes";
+import { collectVersions, VERSIONS } from "./releaseNotes";
 
 describe("release notes helper", () => {
     it("parses version blocks from markdown", () => {
@@ -18,7 +18,7 @@ describe("release notes helper", () => {
             "",
         ].join("\n");
 
-        const versions = parseVersions(markdown);
+        const versions = collectVersions(markdown);
 
         expect(versions).toHaveLength(2);
         expect(versions[0]?.version).toBe("1.2.3");

--- a/src/helpers/releaseNotes.ts
+++ b/src/helpers/releaseNotes.ts
@@ -6,7 +6,7 @@ export interface Version {
     changes: string;
 }
 
-export const parseVersions = (markdown: string) => {
+export const collectVersions = (markdown: string) => {
     const lines = markdown.split("\n");
 
     const versions: Version[] = [];
@@ -42,4 +42,4 @@ export const parseVersions = (markdown: string) => {
     return versions;
 };
 
-export const VERSIONS = parseVersions(Changelog);
+export const VERSIONS = collectVersions(Changelog);


### PR DESCRIPTION
Enhance release notes with clickable GitHub issue links and notify users when a new version is loaded. This update improves user experience by providing direct access to issue discussions and welcoming users to the latest version.